### PR TITLE
Update Bruenig source to 2014 archive

### DIFF
--- a/read.tex
+++ b/read.tex
@@ -23,7 +23,7 @@
 		
 		\item \textbf{"Violence Vouchers: a descriptive account of property" by Matt Bruenig} 
 		
-		\qrcode[height=30mm]{https://web.archive.org/web/20250426111925/https://mattbruenig.com/2014/03/28/violence-vouchers-a-descriptive-account-of-property/}
+		\qrcode[height=30mm]{https://web.archive.org/web/20140401094045/http://mattbruenig.com/2014/03/28/violence-vouchers-a-descriptive-account-of-property}
 		
 		\item \textbf{Source Of This Document}
 		


### PR DESCRIPTION
The links on the site are much less linkrotten on the 2014 version of the archive, removing a distracting barrier to reading more. I ensured the text contents are the same between the old and new links.